### PR TITLE
Fix magento script getContainerNameByType

### DIFF
--- a/magento
+++ b/magento
@@ -83,7 +83,7 @@ getContainerNameByType() {
         return 1
     fi
 
-    local containerName=$($DOCKER ps -q | $XARGS $DOCKER inspect --format '{{.Name}}' | $GREP "$containerNameFragment" | $SED 's:/::' | $GREP "$CONTAINER_TYPE_1")
+    local containerName=$($DOCKER ps -q | $XARGS $DOCKER inspect --format '{{.Name}}' | $GREP "$CONTAINER_TYPE" | $SED 's:/::' | $GREP "$CONTAINER_TYPE_1")
     echo $containerName
     return 0
 }


### PR DESCRIPTION
fix typo in magento script causing commands (magerun, composer, enter) not working correctly