### PR TITLE
update to actual versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "aschroder/smtp_pro": "v2.0.5",
     "gordonlesti/lesti_fpc": "1.3.6",
     "jeroenvermeulen/solarium": "v1.6.9-beta",
-    "magento-hackathon/magento-composer-installer": "v2.1.1",
-    "magento/core": "1.9.1.0-patch1"
+    "magento-hackathon/magento-composer-installer": "3.0.6",
+    "magento/core": "1.9.2.4"
   },
   "require-dev": {
     "aoepeople/aoe_profiler": "v0.3.0",


### PR DESCRIPTION
$ ./magento composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - magento-hackathon/magento-composer-installer 2.1.1 requires composer-plugin-api 1.0.0 -> no matching package found.