### PR TITLE
Fix xdebug

### DIFF
--- a/docker-images/php/Dockerfile
+++ b/docker-images/php/Dockerfile
@@ -23,7 +23,8 @@ RUN buildDeps=" \
     zip \
     && apt-get update -qy && apt-get install -qy git-core \
     && cd /tmp/ && git clone https://github.com/derickr/xdebug.git \
-    && cd xdebug && phpize && ./configure --enable-xdebug && make \
+    && cd xdebug && git reset bbf77a0a6a63b18e834006a7b162808045aad728 --hard \
+    && phpize && ./configure --enable-xdebug && make \
     && mkdir /usr/lib/php5/ && cp modules/xdebug.so /usr/lib/php5/xdebug.so \
     && touch /usr/local/etc/php/ext-xdebug.ini \
     && rm -r /tmp/xdebug && apt-get purge -y git-core \


### PR DESCRIPTION
xdebug dropped support for php 5.6 so it’s necessary to reset before it.
https://github.com/derickr/xdebug/commit/65aefff410626183853a5aa3968855a1621ded0c